### PR TITLE
DAT-14829

### DIFF
--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -6,14 +6,6 @@ on:
       - "Publish Redirects to Staging for Docs"
     types:
       - completed
-  push:
-    branches:
-      - master
-    paths:
-      - 'scripts/redirect_creation/**'
-  pull_request:
-    branches:
-      - master
     paths:
       - 'scripts/redirect_creation/**'
 

--- a/scripts/redirect_creation/variables.tf
+++ b/scripts/redirect_creation/variables.tf
@@ -1,6 +1,7 @@
 # REDIRECT STORAGE FOR docs.liquibase.com: specifies redirect sources/destinations for all pagemoves and renames
 # See https://datical.atlassian.net/wiki/spaces/DOC/pages/2929426585/Working+in+the+MadCap+Flare+-+AWS+VM
 # DAT-12359 move map of redirects to https://github.com/Datical/liquibase-docs/tree/master/scripts
+
 variable "env" {
   type        = string
   description = "Environment to reference.  Should be staging || prod"
@@ -762,6 +763,6 @@ variable "redirects" {
 variable "enterprise_redirects" {
   type = map(string)
   default = {
-# Need to get a list of re-directs from @adrian or @amber
+  # Need to get a list of re-directs from @adrian or @amber
   }
 }


### PR DESCRIPTION
removing on pull/push to master from `Publish Redirects to Staging for EnterpriseDocs`
Also, the testing of DAT-14829 seems to be working:
run 1 : https://github.com/liquibase/liquibase-docs/actions/runs/5337231333/jobs/9672984438?pr=190
run2 after run1 finished : https://github.com/liquibase/liquibase-docs/actions/runs/5337237998