### PR TITLE
DAT-16244 docs terraform migration without using spacectl cli

### DIFF
--- a/.github/workflows/promote-enterprisedocs-staging-to-production.yml
+++ b/.github/workflows/promote-enterprisedocs-staging-to-production.yml
@@ -27,16 +27,14 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "prod"
+      SPACELIFT_API_KEY_ENDPOINT: https://liquibase.app.spacelift.io
+      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
+      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
     defaults:
       run:
         working-directory: scripts/redirect_creation
     steps:
       - uses: actions/checkout@v3
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/promote-enterprisedocs-staging-to-production.yml
+++ b/.github/workflows/promote-enterprisedocs-staging-to-production.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "prod"
-      SPACELIFT_API_KEY_ENDPOINT: https://liquibase.app.spacelift.io
+      SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
       SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
       SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
     defaults:

--- a/.github/workflows/promote-enterprisedocs-staging-to-production.yml
+++ b/.github/workflows/promote-enterprisedocs-staging-to-production.yml
@@ -27,9 +27,8 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "prod"
-      SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
-      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
-      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+      TF_TOKEN_spacelift_io: ${{ secrets.SPACELIFT_API_KEY }}
+
     defaults:
       run:
         working-directory: scripts/redirect_creation
@@ -48,5 +47,5 @@ jobs:
         run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend 
 
       - name: Terraform Apply
-        run: terraform apply -target=aws_s3_object.enterprise_redirects -auto-approve
+        run: terraform apply -target=aws_s3_object.enterprise_redirects -auto-approve -lock=false
      

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -28,9 +28,8 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "prod"
-      SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
-      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
-      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+      TF_TOKEN_spacelift_io: ${{ secrets.SPACELIFT_API_KEY }}
+
     defaults:
       run:
         working-directory: scripts/redirect_creation
@@ -49,4 +48,4 @@ jobs:
         run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend 
 
       - name: Terraform Apply
-        run: terraform apply -auto-approve
+        run: terraform apply -auto-approve -lock=false

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -28,16 +28,14 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "prod"
+      SPACELIFT_API_KEY_ENDPOINT: https://liquibase.app.spacelift.io
+      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
+      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
     defaults:
       run:
         working-directory: scripts/redirect_creation
     steps:
       - uses: actions/checkout@v3
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "prod"
-      SPACELIFT_API_KEY_ENDPOINT: https://liquibase.app.spacelift.io
+      SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
       SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
       SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
     defaults:

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -1,6 +1,7 @@
 # Terraform Action to lint and apply updated redirects
 name: Publish Redirects to Staging for Docs
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -37,6 +37,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_hostname: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
+          cli_config_credentials_token: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+          
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}
         id: fmt

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "staging"
-      SPACELIFT_API_KEY_ENDPOINT: https://liquibase.app.spacelift.io
+      SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
       SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
       SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
     defaults:

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -39,8 +39,9 @@ jobs:
 
       - name: Configure Spacelift credentials
         run: |
-          echo "credentials \"spacelift.io\" { \
-            token = \"${{ secrets.SPACELIFT_API_TOKEN }}\"}" > ~/.terraformrc
+          echo "{ \"credentials\": { \"spacelift.io\": { \
+            \"token\" = \"${{ secrets.SPACELIFT_API_TOKEN }}\"} } }" > ~/.terraform.d/credentials.tfrc.json
+          cat ~/.terraform.d/credentials.tfrc.json
           
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           mkdir -p ~/.terraform.d
           echo "{ \"credentials\": { \"spacelift.io\": { \
-            \"token\" = \"${{ secrets.SPACELIFT_API_TOKEN }}\"} } }" > ~/.terraform.d/credentials.tfrc.json
+            \"token\": \"${{ secrets.SPACELIFT_API_TOKEN }}\"} } }" > ~/.terraform.d/credentials.tfrc.json
           cat ~/.terraform.d/credentials.tfrc.json
           
       - name: Terraform Format

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -45,10 +45,8 @@ jobs:
 
       - name: Configure Spacelift credentials
         run: |
-          echo "credentials \"spacelift.io\" {
-            token = \${{ secrets.SPACELIFT_API_KEY_SECRET }}
-          }" > ~/.terraformrc
-
+          echo "credentials \"spacelift.io\" { \
+            token = \"${{ secrets.SPACELIFT_API_TOKEN }}\"}" > ~/.terraformrc
           
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         id: plan
         run: |
-          terraform plan -out=plan.tmp
+          terraform plan -out=plan.tmp -lock=false
           terraform show -no-color plan.tmp >${GITHUB_WORKSPACE}/plan.out
         continue-on-error: false
 

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "staging"
-      TF_TOKEN_spacelift_io: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+      TF_TOKEN_spacelift_io: ${{ secrets.SPACELIFT_API_KEY }}
 
     defaults:
       run:

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "staging"
+      SPACELIFT_API_KEY_ENDPOINT: https://liquibase.app.spacelift.io
+      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
+      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
     defaults:
       run:
         working-directory: scripts/redirect_creation
@@ -25,11 +28,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch }}
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -37,10 +37,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
 
-      - name: Set up credentials
-        run: |
-          echo "credentials \"spacelift.io\" { \
-            token = \"${{ secrets.SPACELIFT_API_TOKEN }}\"}" > /home/runner/.terraformrc
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_hostname: 'spacelift.io'
+          cli_config_credentials_token: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
           
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -18,9 +18,8 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "staging"
-      SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
-      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
-      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+      TF_TOKEN_spacelift_io: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+
     defaults:
       run:
         working-directory: scripts/redirect_creation
@@ -36,13 +35,6 @@ jobs:
           aws-access-key-id: ${{ secrets.DOCS_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
-
-      - name: Configure Spacelift credentials
-        run: |
-          mkdir -p ~/.terraform.d
-          echo "{ \"credentials\": { \"spacelift.io\": { \
-            \"token\": \"${{ secrets.SPACELIFT_API_TOKEN }}\"} } }" > ~/.terraform.d/credentials.tfrc.json
-          cat ~/.terraform.d/credentials.tfrc.json
           
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Terraform Init
         id: init
-        run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend -migrate-state
+        run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend -reconfigure
 
       - name: Terraform Validate
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -37,12 +37,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          cli_config_credentials_hostname: 'spacelift.io'
-          cli_config_credentials_token: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
-
       - name: Configure Spacelift credentials
         run: |
           echo "credentials \"spacelift.io\" { \
@@ -115,4 +109,4 @@ jobs:
 
       - name: Terraform Apply
         if: ${{ github.event_name == 'push' }}
-        run: terraform apply -auto-approve
+        run: #terraform apply -auto-approve

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -109,4 +109,5 @@ jobs:
 
       - name: Terraform Apply
         if: ${{ github.event_name == 'push' }}
-        run: #terraform apply -auto-approve
+        run: |
+          #terraform apply -auto-approve

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -37,11 +37,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          cli_config_credentials_hostname: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
-          cli_config_credentials_token: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+      - name: Set up credentials
+        run: |
+          echo "credentials \"spacelift.io\" { \
+            token = \"${{ secrets.SPACELIFT_API_TOKEN }}\"}" > /home/runner/.terraformrc
           
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -1,7 +1,6 @@
 # Terraform Action to lint and apply updated redirects
 name: Publish Redirects to Staging for Docs
 on:
-  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Terraform Init
         id: init
-        run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend -reconfigure
+        run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend 
 
       - name: Terraform Validate
         if: ${{ github.event_name == 'pull_request' }}
@@ -54,7 +54,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         id: plan
         run: |
-          terraform plan -out=plan.tmp
+          terraform plan -out=plan.tmp -lock=false
           terraform show -no-color plan.tmp >${GITHUB_WORKSPACE}/plan.out
         continue-on-error: false
 
@@ -104,4 +104,4 @@ jobs:
       - name: Terraform Apply
         if: ${{ github.event_name == 'push' }}
         run: |
-          #terraform apply -auto-approve
+          terraform apply -auto-approve -lock=false

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Configure Spacelift credentials
         run: |
+          mkdir -p ~/.terraform.d
           echo "{ \"credentials\": { \"spacelift.io\": { \
             \"token\" = \"${{ secrets.SPACELIFT_API_TOKEN }}\"} } }" > ~/.terraform.d/credentials.tfrc.json
           cat ~/.terraform.d/credentials.tfrc.json

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Terraform Init
         id: init
-        run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend 
+        run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend -migrate-state
 
       - name: Terraform Validate
         if: ${{ github.event_name == 'pull_request' }}
@@ -54,7 +54,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         id: plan
         run: |
-          terraform plan -out=plan.tmp -lock=false
+          terraform plan -out=plan.tmp
           terraform show -no-color plan.tmp >${GITHUB_WORKSPACE}/plan.out
         continue-on-error: false
 

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -37,12 +37,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
 
-
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
           cli_config_credentials_hostname: 'spacelift.io'
           cli_config_credentials_token: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+
+      - name: Configure Spacelift credentials
+        run: |
+          echo "credentials \"spacelift.io\" {
+            token = \${{ secrets.SPACELIFT_API_KEY_SECRET }}
+          }" > ~/.terraformrc
+
           
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -14,9 +14,8 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "staging"
-      SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
-      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
-      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+      TF_TOKEN_spacelift_io: ${{ secrets.SPACELIFT_API_KEY }}
+
     defaults:
       run:
         working-directory: scripts/redirect_creation
@@ -32,12 +31,6 @@ jobs:
           aws-access-key-id: ${{ secrets.DOCS_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          cli_config_credentials_hostname: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
-          cli_config_credentials_token: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
 
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "staging"
+      SPACELIFT_API_KEY_ENDPOINT: https://liquibase.app.spacelift.io
+      SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
+      SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
     defaults:
       run:
         working-directory: scripts/redirect_creation
@@ -22,11 +25,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch }}
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -50,7 +50,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         id: plan
         run: |
-          terraform plan -out=plan.tmp
+          terraform plan -out=plan.tmp -lock=false
           terraform show -no-color plan.tmp >${GITHUB_WORKSPACE}/plan.out
         continue-on-error: false
 
@@ -99,4 +99,4 @@ jobs:
 
       - name: Terraform Apply
         if: ${{ github.event_name == 'push' }}
-        run: terraform apply -target=aws_s3_object.enterprise_redirects -auto-approve
+        run: terraform apply -target=aws_s3_object.enterprise_redirects -auto-approve -lock=false

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -33,6 +33,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_hostname: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
+          cli_config_credentials_token: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
+
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}
         id: fmt

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       TF_VAR_env: "staging"
-      SPACELIFT_API_KEY_ENDPOINT: https://liquibase.app.spacelift.io
+      SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}
       SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
       SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
     defaults:

--- a/scripts/redirect_creation/main.tf
+++ b/scripts/redirect_creation/main.tf
@@ -7,6 +7,7 @@ terraform {
 data "terraform_remote_state" "state" {
   backend = "remote"
   config = {
+    hostname     = "spacelift.io"
     organization = "liquibase"
     workspaces = {
       name = "liquibase-${var.env}"

--- a/scripts/redirect_creation/main.tf
+++ b/scripts/redirect_creation/main.tf
@@ -1,5 +1,7 @@
 
-
+terraform {
+  backend "remote" {}
+}
 
 # use Terraform Remote State Data stanza to read state from environment-based workspace
 data "terraform_remote_state" "state" {
@@ -8,7 +10,7 @@ data "terraform_remote_state" "state" {
     hostname     = "spacelift.io"
     organization = "liquibase"
     workspaces = {
-      name = "liquibase-prod"
+      name = "liquibase-${var.env}"
     }
   }
 }

--- a/scripts/redirect_creation/main.tf
+++ b/scripts/redirect_creation/main.tf
@@ -1,7 +1,5 @@
 
-terraform {
-  backend "remote" {}
-}
+
 
 # use Terraform Remote State Data stanza to read state from environment-based workspace
 data "terraform_remote_state" "state" {
@@ -10,7 +8,7 @@ data "terraform_remote_state" "state" {
     hostname     = "spacelift.io"
     organization = "liquibase"
     workspaces = {
-      name = "liquibase-${var.env}"
+      name = "liquibase-staging"
     }
   }
 }

--- a/scripts/redirect_creation/main.tf
+++ b/scripts/redirect_creation/main.tf
@@ -1,4 +1,7 @@
 
+terraform {
+  backend "remote" {}
+}
 
 # use Terraform Remote State Data stanza to read state from environment-based workspace
 data "terraform_remote_state" "state" {

--- a/scripts/redirect_creation/main.tf
+++ b/scripts/redirect_creation/main.tf
@@ -1,7 +1,4 @@
 
-terraform {
-  backend "remote" {}
-}
 
 # use Terraform Remote State Data stanza to read state from environment-based workspace
 data "terraform_remote_state" "state" {

--- a/scripts/redirect_creation/main.tf
+++ b/scripts/redirect_creation/main.tf
@@ -8,7 +8,7 @@ data "terraform_remote_state" "state" {
     hostname     = "spacelift.io"
     organization = "liquibase"
     workspaces = {
-      name = "liquibase-staging"
+      name = "liquibase-prod"
     }
   }
 }

--- a/scripts/redirect_creation/prod.remote.tfbackend
+++ b/scripts/redirect_creation/prod.remote.tfbackend
@@ -1,3 +1,4 @@
 #Selecting the prod TF Cloud workspace
 workspaces { name = "liquibase-docs-prod" }
 organization = "liquibase"
+hostname     = "spacelift.io"

--- a/scripts/redirect_creation/staging.remote.tfbackend
+++ b/scripts/redirect_creation/staging.remote.tfbackend
@@ -1,4 +1,4 @@
-#Selecting the staging TF Cloud workspace
+#Selecting the staging spacelift workspace
 workspaces { name = "liquibase-docs-staging" }
 organization = "liquibase"
 hostname     = "spacelift.io"

--- a/scripts/redirect_creation/staging.remote.tfbackend
+++ b/scripts/redirect_creation/staging.remote.tfbackend
@@ -1,3 +1,4 @@
 #Selecting the staging TF Cloud workspace
 workspaces { name = "liquibase-docs-staging" }
 organization = "liquibase"
+hostname     = "spacelift.io"

--- a/scripts/redirect_creation/variables.tf
+++ b/scripts/redirect_creation/variables.tf
@@ -2,10 +2,7 @@
 # See https://datical.atlassian.net/wiki/spaces/DOC/pages/2929426585/Working+in+the+MadCap+Flare+-+AWS+VM
 # DAT-12359 move map of redirects to https://github.com/Datical/liquibase-docs/tree/master/scripts
 
-variable "env" {
-  type        = string
-  description = "Environment to reference.  Should be staging || prod"
-}
+
 
 variable "redirects" {
   default = [

--- a/scripts/redirect_creation/variables.tf
+++ b/scripts/redirect_creation/variables.tf
@@ -2,7 +2,10 @@
 # See https://datical.atlassian.net/wiki/spaces/DOC/pages/2929426585/Working+in+the+MadCap+Flare+-+AWS+VM
 # DAT-12359 move map of redirects to https://github.com/Datical/liquibase-docs/tree/master/scripts
 
-
+variable "env" {
+  type        = string
+  description = "Environment to reference.  Should be staging || prod"
+}
 
 variable "redirects" {
   default = [


### PR DESCRIPTION
I made the following changes in our Spacelift configuration repo to allow us to import the current states for both `liquibase-docs-staging` and `liquibase-docs-prod`: https://github.com/liquibase/spacelift/pull/6/files

You can checkout this PR branch and `cd` into `scripts/redirect_creation` to test it by just running the same terraform commands shown at `liquibase-docs/.github/workflows/send-docs-redirects-to-staging.yml`

The local test I did (be sure to be logged to our AWS liquibase-admin account):

```
terraform login spacelift.io
terraform init -backend-config=staging.remote.tfbackend
terraform plan 
```

![image](https://github.com/liquibase/liquibase-docs/assets/67458478/1c35cf0d-623a-45bd-94e8-c4c2a947513b)
