### PR TITLE
wait for concurrent workflows step to prevent race conditions

### DIFF
--- a/.github/workflows/promote-enterprisedocs-staging-to-production.yml
+++ b/.github/workflows/promote-enterprisedocs-staging-to-production.yml
@@ -42,6 +42,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
 
+      - name: Wait for concurrent workflows
+        uses: ahmadnassri/action-workflow-queue@v1
+
       - name: Terraform Init
         id: init
         run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend 

--- a/.github/workflows/promote-enterprisedocs-staging-to-production.yml
+++ b/.github/workflows/promote-enterprisedocs-staging-to-production.yml
@@ -50,5 +50,5 @@ jobs:
         run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend 
 
       - name: Terraform Apply
-        run: terraform apply -target=aws_s3_object.enterprise_redirects -auto-approve -lock=false
+        run: terraform apply -target=aws_s3_object.enterprise_redirects -auto-approve
      

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -51,4 +51,4 @@ jobs:
         run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend 
 
       - name: Terraform Apply
-        run: terraform apply -auto-approve -lock=false
+        run: terraform apply -auto-approve

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -43,6 +43,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
 
+      - name: Wait for concurrent workflows
+        uses: ahmadnassri/action-workflow-queue@v1
+
       - name: Terraform Init
         id: init
         run: terraform init -backend-config=$TF_VAR_env.remote.tfbackend 

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -107,4 +107,4 @@ jobs:
       - name: Terraform Apply
         if: ${{ github.event_name == 'push' }}
         run: |
-          terraform apply -auto-approve -lock=false
+          terraform apply -auto-approve

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -1,6 +1,7 @@
 # Terraform Action to lint and apply updated redirects
 name: Publish Redirects to Staging for Docs
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -34,6 +35,9 @@ jobs:
           aws-access-key-id: ${{ secrets.DOCS_AWS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
+
+      - name: Wait for concurrent workflows
+        uses: ahmadnassri/action-workflow-queue@v1
           
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -1,7 +1,6 @@
 # Terraform Action to lint and apply updated redirects
 name: Publish Redirects to Staging for Docs
 on:
-  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -102,4 +102,4 @@ jobs:
 
       - name: Terraform Apply
         if: ${{ github.event_name == 'push' }}
-        run: terraform apply -target=aws_s3_object.enterprise_redirects -auto-approve -lock=false
+        run: terraform apply -target=aws_s3_object.enterprise_redirects -auto-approve

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -32,6 +32,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
           aws-region: us-east-1
 
+      - name: Wait for concurrent workflows
+        uses: ahmadnassri/action-workflow-queue@v1
+
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}
         id: fmt


### PR DESCRIPTION
chore(workflows): add wait for concurrent workflows step to prevent race conditions

The workflows `promote-enterprisedocs-staging-to-production.yml`, `promote-staging-to-production.yml`, `send-docs-redirects-to-staging.yml`, and `send-enterprise-redirects-to-staging.yml` have been updated to include a new step that waits for concurrent workflows to finish before proceeding. This is done to prevent race conditions and ensure that the workflows are executed in the correct order. The `ahmadnassri/action-workflow-queue` action is used for this purpose.