### PR TITLE
revert dummy redirect

### DIFF
--- a/scripts/redirect_creation/variables.tf
+++ b/scripts/redirect_creation/variables.tf
@@ -862,8 +862,7 @@ variable "redirects" {
     { key = "/workflows/liquibase-community/creating-config-properties.html", website_redirect = "/concepts/connections/creating-config-properties.html" },
     { key = "/workflows/liquibase-community/generating-docs.html", website_redirect = "/commands/change-tracking/db-doc.html" },
     { key = "/workflows/liquibase-community/liquibase-auto-rollback.html", website_redirect = "/workflows/liquibase-community/automatic-custom-rollbacks.html" },
-    { key = "/workflows/liquibase-community/run-liquibase-without-launch-scripts.html", website_redirect = "/workflows/liquibase-community/liquibase-launch-script.html" },
-    { key = "/workflows/liquibase-community/test-spacelift.html", website_redirect = "/workflows/liquibase-community/test-spacelift.html" }
+    { key = "/workflows/liquibase-community/run-liquibase-without-launch-scripts.html", website_redirect = "/workflows/liquibase-community/liquibase-launch-script.html" }
   ]
 }
 


### PR DESCRIPTION
…from variables.tf

The test-spacelift redirect was mistakenly included in the redirects list in variables.tf. This commit removes the unnecessary redirect to improve the clarity and maintainability of the code.