### PR TITLE
DAT-11513      DevOps :: Enable OIDC for Github / AWS Integration

### DIFF
--- a/.github/workflows/promote-enterprisedocs-staging-to-production.yml
+++ b/.github/workflows/promote-enterprisedocs-staging-to-production.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   content:
     runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
     defaults:
       run:
         working-directory: scripts/redirect_creation
@@ -24,6 +27,9 @@ jobs:
               
   redirects:
     runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
     env:
       TF_VAR_env: "prod"
       SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}

--- a/.github/workflows/promote-enterprisedocs-staging-to-production.yml
+++ b/.github/workflows/promote-enterprisedocs-staging-to-production.yml
@@ -15,8 +15,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.DOCS_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1
 
       - name: Promote Staging Content to Production
@@ -44,8 +43,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.DOCS_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1
 
       - name: Deploy infrastructure

--- a/.github/workflows/promote-enterprisedocs-staging-to-production.yml
+++ b/.github/workflows/promote-enterprisedocs-staging-to-production.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1
@@ -41,7 +41,7 @@ jobs:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1

--- a/.github/workflows/promote-enterprisedocs-staging-to-production.yml
+++ b/.github/workflows/promote-enterprisedocs-staging-to-production.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       id-token: write
-      contents: read
+      contents: write
     defaults:
       run:
         working-directory: scripts/redirect_creation
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       id-token: write
-      contents: read
+      contents: write
     env:
       TF_VAR_env: "prod"
       SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       id-token: write
-      contents: read
+      contents: write
     defaults:
       run:
         working-directory: scripts/redirect_creation
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       id-token: write
-      contents: read
+      contents: write
     env:
       TF_VAR_env: "prod"
       SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -16,8 +16,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.DOCS_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1
 
       - name: Promote Staging Content to Production
@@ -45,8 +44,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.DOCS_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1
 
       - name: Deploy infrastructure

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   content:
     runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
     defaults:
       run:
         working-directory: scripts/redirect_creation
@@ -25,6 +28,9 @@ jobs:
           
   redirects:
     runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
     env:
       TF_VAR_env: "prod"
       SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1
@@ -42,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -37,8 +37,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.DOCS_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1
 
       - name: Terraform Format

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -64,6 +64,7 @@ jobs:
 
       - name: Terraform Show Plan in PR
         uses: actions/github-script@v6
+        continue-on-error: true        
         if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   publish-docs-staging-redirects:
     runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
     env:
       TF_VAR_env: "staging"
       SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       id-token: write
-      contents: read
+      contents: write
     env:
       TF_VAR_env: "staging"
       SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}

--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   publish-enterprise-staging-redirects:
     runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: read
     env:
       TF_VAR_env: "staging"
       SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       id-token: write
-      contents: read
+      contents: write
     env:
       TF_VAR_env: "staging"
       SPACELIFT_API_KEY_ENDPOINT: ${{ secrets.SPACELIFT_API_KEY_ENDPOINT }}

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -32,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Terraform Show Plan in PR
         uses: actions/github-script@v6
+        continue-on-error: true
         if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/send-enterprise-redirects-to-staging.yml
+++ b/.github/workflows/send-enterprise-redirects-to-staging.yml
@@ -34,8 +34,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.DOCS_AWS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.DOCS_AWS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1
 
       - name: Terraform Format

--- a/scripts/redirect_creation/variables.tf
+++ b/scripts/redirect_creation/variables.tf
@@ -909,7 +909,8 @@ variable "redirects" {
     { key = "/workflows/liquibase-community/using-liquibase-with-spinnaker.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/integration-docs/Spinnaker/overview/" },
     { key = "/workflows/liquibase-community/using-the-liquibase-percona-toolkit-extension.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/database-tutorials/percona/percona-toolkit/" },
     { key = "/workflows/liquibase-community/using-the-jenkins-pipeline-stage-with-spinnaker.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/integration-docs/Spinnaker/spinnaker-jenkins-pipeline-stage/" },
-    { key = "/workflows/liquibase-community/using-the-run-job-pipeline-stage-with-spinnaker.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/integration-docs/Spinnaker/spinnaker-runjob-pipeline-stage/" }
+    { key = "/workflows/liquibase-community/using-the-run-job-pipeline-stage-with-spinnaker.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/integration-docs/Spinnaker/spinnaker-runjob-pipeline-stage/" },
+    { key = "/workflows/liquibase-community/using-the-run-job-pipeline-stage-with-spinnaker-test.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/integration-docs/Spinnaker/spinnaker-runjob-pipeline-stage-test/" }
   ]
 }
 

--- a/scripts/redirect_creation/variables.tf
+++ b/scripts/redirect_creation/variables.tf
@@ -909,8 +909,7 @@ variable "redirects" {
     { key = "/workflows/liquibase-community/using-liquibase-with-spinnaker.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/integration-docs/Spinnaker/overview/" },
     { key = "/workflows/liquibase-community/using-the-liquibase-percona-toolkit-extension.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/database-tutorials/percona/percona-toolkit/" },
     { key = "/workflows/liquibase-community/using-the-jenkins-pipeline-stage-with-spinnaker.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/integration-docs/Spinnaker/spinnaker-jenkins-pipeline-stage/" },
-    { key = "/workflows/liquibase-community/using-the-run-job-pipeline-stage-with-spinnaker.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/integration-docs/Spinnaker/spinnaker-runjob-pipeline-stage/" },
-    { key = "/workflows/liquibase-community/using-the-run-job-pipeline-stage-with-spinnaker-test.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/integration-docs/Spinnaker/spinnaker-runjob-pipeline-stage-test/" }
+    { key = "/workflows/liquibase-community/using-the-run-job-pipeline-stage-with-spinnaker.html", website_redirect = "https://contribute.liquibase.com/extensions-integrations/directory/integration-docs/Spinnaker/spinnaker-runjob-pipeline-stage/" }
   ]
 }
 


### PR DESCRIPTION
chore(workflows): update AWS credentials configuration in promote-enterprisedocs-staging-to-production.yml, promote-staging-to-production.yml, send-docs-redirects-to-staging.yml, and send-enterprise-redirects-to-staging.yml

The AWS credentials configuration in the mentioned workflow files has been updated to use the `role-to-assume` parameter instead of `aws-access-key-id` and `aws-secret-access-key`. This change improves security by using AWS Identity and Access Management (IAM) roles for authentication instead of static access keys. The `role-to-assume` parameter specifies the IAM role to assume when configuring the AWS credentials.