### PR TITLE
DAT-19181 GitHub Actions Error: uploading S3 Object to Bucket

### DIFF
--- a/.github/workflows/send-docs-redirects-to-staging.yml
+++ b/.github/workflows/send-docs-redirects-to-staging.yml
@@ -41,6 +41,15 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ADMIN_GITHUB_OIDC_ROLE_ARN_DOCS }}
           aws-region: us-east-1
 
+      - name: Check website redirects format
+        run: |
+          if grep -P 'website_redirect\s*=\s*"[^/]' variables.tf; then
+            echo "Error: Found website_redirect that doesn't start with '/'"
+            echo "All website_redirect values must start with a forward slash"
+            echo "Example: website_redirect = \"/home.html\""
+            exit 1
+          fi
+
       - name: Terraform Format
         if: ${{ github.event_name == 'pull_request' }}
         id: fmt


### PR DESCRIPTION
This pull request introduces a new validation step to the GitHub Actions workflow for sending documentation redirects to staging. The most important change is the addition of a check to ensure that all `website_redirect` values in `variables.tf` start with a forward slash.

Validation step added:

* [`.github/workflows/send-docs-redirects-to-staging.yml`](diffhunk://#diff-58911b4c1d2ff6532663eb431ccfb33bf5b0754725058deaf4fc0aa71bf6e3daR44-R52): Added a step to check the format of `website_redirect` values in `variables.tf`, ensuring they start with a forward slash.